### PR TITLE
chore: initialize project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+.DS_Store
+/vscode
+**.zip

--- a/README.md
+++ b/README.md
@@ -52,16 +52,18 @@ Track changes across your `style`, `script` and `theme` folder, auto-update your
 
 ## What's Included?
 
-- **Theme Boilerplate** - A starter theme/boilerplate code with essential files and configurations to jumpstart theme development with your selected css framework baked in ready to use.
+- **Scaffold Themes** - Quickly generate new WordPress theme with essential files and configurations to jumpstart theme development with your selected css framework baked in ready to use.
 
-- **Hot Reload** - automatically updates your code in real-time as you make changes to your code, ensuring that your changes are instantly reflected in the browser without requiring manual refreshes.
+- **Hot Reload** - Experience Automatically updates your code in real-time as you make changes to your code, ensuring that your changes are instantly reflected in the browser without requiring manual refreshes.
 
 - **Live Tunnel** - Exposes your local development environment (i.e. localhost) publicly accessible URL online, lets you showcase and test your WordPress theme in a live environment, allowing collaborators and your clients to preview your work.
 
-- **Script Bundler** - Ready to bundle JavaScript files, making it easier to manage dependencies and optimize the performance of your theme.
+- **Script Bundling** - Ready to bundle JavaScript files, making it easier to manage dependencies and optimize the performance of your theme.
 
-- **Style Compiler/Bundler** - A Compiler ready to transform your Sass/SCSS or plain CSS files into compressed CSS, allowing you to write styles more efficiently and modularly.
+- **Style Compilation/Bundling** - A Compiler ready to transform your Sass/SCSS or plain CSS files into compressed CSS, allowing you to write styles more efficiently and modularly.
 
-- **Style Prefixer** - Get automatic addition of vendor prefixes to CSS code, to ensuring that your styles works correctly and its compatible across different web browsers.
+- **Style Prefixing** - Get automatic addition of vendor prefixes to CSS code, to ensuring that your styles works correctly and its compatible across different web browsers.
 
-- **Theme Bundler (with Automatic Versioning)** - Generate your final production-ready theme bundle zip with automatic version incrementing in the `funtions.php` file.
+- **Theme Bundling (with Automatic Versioning)** - Generate your final production-ready theme bundle zip with automatic version incrementing in the `funtions.php` file.
+
+Whether you're a seasoned developer or just starting with WordPress theme development, the Create WP Theme Toolkit empowers you to create exceptional themes with ease.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
-# create-wp-theme
+# Create WordPress Theme
+
+A one-stop solution for crafting WordPress themes with finesse. Seamlessly bundled with a powerful tools that simplifies your development workflow.
+
+```shell
+npx create-wp-theme <theme-name>
+```
+
+## Quick start
+
+### Online Generator
+
+Get Started by generating your theme with your favorite CSS framework with our [online generator](#)
+
+or
+
+### CLI Tool
+
+You can use our cli tool by running the command below with your favorite CSS framework:
+
+### Bootstrap
+
+```shell
+npx create-wp-theme <theme-name> --bootstrap
+```
+
+### Material Design
+
+```shell
+npx create-wp-theme <theme-name> --material
+```
+
+### Installation
+
+1. Move this folder to `wp-content/themes` in your local development environment
+2. Navigate into your theme's folder and run `npm install && npm run dev` 
+3. Activate the theme in your WordPress administrative panel
+
+### Development
+
+#### Without Hot Reload
+Track changes in your `style` and `script` folder and build the output in real-time.
+
+4. Run `npm run watch`
+
+#### With Hot Reload (Recommended)
+Track changes across your `style`, `script` and `theme` folder, auto-update your theme in real-time and refreshes your browser.
+
+4. Open the `package.json` and replace the url string `dev.local` in the `watch:changes` script with the url of your currently running server
+5. Run `npm run serve` or if you would like to enable a tunnel exposing your localhost to a publicly available url, run `npm run serve:tunnel`.
+
+### Deployment
+
+6. Run `npm run build`
+7. Take the resulting `zip` file and upload to your website, through the administrative panel's appearance upload theme page.
+
+## What's Included?
+
+- **Theme Boilerplate** - A starter theme/boilerplate code with essential files and configurations to jumpstart theme development with your selected css framework baked in ready to use.
+
+- **Hot Reload** - automatically updates your code in real-time as you make changes to your code, ensuring that your changes are instantly reflected in the browser without requiring manual refreshes.
+
+- **Live Tunnel** - Exposes your local development environment (i.e. localhost) publicly accessible URL online, lets you showcase and test your WordPress theme in a live environment, allowing collaborators and your clients to preview your work.
+
+- **Script Bundler** - Ready to bundle JavaScript files, making it easier to manage dependencies and optimize the performance of your theme.
+
+- **Style Compiler/Bundler** - A Compiler ready to transform your Sass/SCSS or plain CSS files into compressed CSS, allowing you to write styles more efficiently and modularly.
+
+- **Style Prefixer** - Get automatic addition of vendor prefixes to CSS code, to ensuring that your styles works correctly and its compatible across different web browsers.
+
+- **Theme Bundler (with Automatic Versioning)** - Generate your final production-ready theme bundle zip with automatic version incrementing in the `funtions.php` file.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 A one-stop solution for crafting WordPress themes with finesse. Seamlessly bundled with a powerful tools that simplifies your development workflow.
 
-```shell
-npx create-wp-theme <theme-name>
-```
-
 ## Quick start
 
 ### Online Generator

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,47 @@
+# Create WordPress Theme CLI
+
+Create WP Theme CLI is a command-line tool designed to streamline WordPress theme development. With an intuitive interface, it empowers you to create, manage, and customize WordPress themes effortlessly.
+
+```shell
+npx create-wp-theme <theme-name>
+```
+
+## Quick start
+
+Generate your starter theme/boilerplate with your favorite CSS framework by running the command below:
+
+### Bootstrap
+
+```shell
+npx create-wp-theme <theme-name> --bootstrap
+```
+
+### Material Design
+
+```shell
+npx create-wp-theme <theme-name> --material
+```
+
+### Installation
+
+1. Move this folder to `wp-content/themes` in your local development environment
+2. Navigate into your theme's folder and run `npm install && npm run dev` 
+3. Activate the theme in your WordPress administrative panel
+
+### Development
+
+#### Without Hot Reload
+Track changes in your `style` and `script` folder and build the output in real-time.
+
+4. Run `npm run watch`
+
+#### With Hot Reload (Recommended)
+Track changes across your `style`, `script` and `theme` folder, auto-update your theme in real-time and refreshes your browser.
+
+4. Open the `package.json` and replace the url string `dev.local` in the `watch:changes` script with the url of your currently running server
+5. Run `npm run serve` or if you would like to enable a tunnel exposing your localhost to a publicly available url, run `npm run serve:tunnel`.
+
+### Deployment
+
+6. Run `npm run build`
+7. Take the resulting `zip` file and upload to your website, through the administrative panel's appearance upload theme page.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "create-wp-theme-cli",
+  "version": "0.0.0",
+  "description": "Command-line tool for creating WordPress theme.",
+  "license": "MIT",
+  "bin": {
+    "create-wp-theme": "",
+    "cwpt": ""
+  },
+  "keywords": [
+    "cwpt cli",
+    "create-wordpress-theme cli",
+    "wordpress theme cli",
+    "wordpress theme development cli"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Olabode Lawal-Shittabey <babblebey@gmail.com>"
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "create-wp-theme-docs",
+  "version": "0.0.0",
+  "description": "Command-line tool for creating WordPress theme.",
+  "license": "MIT",
+  "bin": {
+    "create-wp-theme": "",
+    "cwpt": ""
+  },
+  "keywords": [
+    "cwpt documentation",
+    "create-wordpress-theme documentation"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Olabode Lawal-Shittabey <babblebey@gmail.com>"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "create-wp-theme",
+  "version": "0.0.0",
+  "private": true,
+  "description": "An all-in-one WordPress theme development toolkit with JavaScript bundler, sass/css compiler, and live-reloading server.",
+  "keywords": [
+    "wordpress theme development",
+    "wordpress theme boilerplate",
+    "wordpress javascript bundler",
+    "wordpress sass compiler",
+    "bootstrap wordpress template",
+    "wordpress material design template",
+    "browsersync with wordpress",
+    "wordpress theme cli app",
+    "theme customization",
+    "wordpress theme development toolkit",
+    "wordpress theme generator",
+    "front-end development"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Olabode Lawal-Shittabey <babblebey@gmail.com>",
+  "license": "MIT"
+}


### PR DESCRIPTION
Tracking Tasks

- [x] Initialize a `package.json` in parent dir as `create-wp-theme`
- [x] Initialize a `package.json` for the `cli` tool as `create-wp-theme-cli`
- [x] Initialize a `package.json` for the documentation and generator website as `create-wp-theme-docs`
- [x] Update the `README.md` in parent dir for  `create-wp-theme`
- [x] Replicate `README.md` parts for other parts i.e. `create-wp-theme-cli` and `create-wp-theme-docs`
- [x] add `.gitignore` to parent dir 