### PR TITLE
feat: add `cwpt-bootstrap` template

### DIFF
--- a/packages/templates/cwpt-bootstrap/js/main.js
+++ b/packages/templates/cwpt-bootstrap/js/main.js
@@ -1,0 +1,2 @@
+// Uncomment the line below for testing.
+// alert("Hello world from the theme's `main.js`");

--- a/packages/templates/cwpt-bootstrap/package.json
+++ b/packages/templates/cwpt-bootstrap/package.json
@@ -1,0 +1,35 @@
+{
+  "scripts": {
+    "build:scripts": "esbuild ./js/main.js --bundle --outfile=./theme/js/main.js",
+    "build:styles": "sass ./scss/main.scss ./theme/css/main.css",
+    "build:prefix-styles:": "postcss --replace ./theme/css/main.css --use autoprefixer",
+    "development": "run-p build:**",
+    "dev": "npm run development",
+    "watch:scripts": "npm run build:scripts -- --watch",
+    "watch:styles": "npm run build:styles -- --watch",
+    "watch": "run-p watch:scripts watch:styles",
+    "watch:changes": "browser-sync start --proxy \"dev.local\" --files \"theme\" --no-inject-changes --no-notify",
+    "serve": "run-p watch watch:changes",
+    "serve:tunnel": "npm run serve -- --tunnel",
+    "production:scripts": "npm run build:scripts -- --minify",
+    "production:styles": "npm run build:styles -- --style compressed",
+    "production": "run-s production:** build:prefix-styles",
+    "prod": "npm run production",
+    "zip": "node node_scripts/zip.js _cwpt",
+    "bundle": "run-s production zip"
+  },
+  "devDependencies": {
+    "adm-zip": "^0.5.10",
+    "archiver": "^6.0.0",
+    "autoprefixer": "^10.4.15",
+    "bootstrap": "^5.3.1",
+    "browser-sync": "^2.29.3",
+    "esbuild": "0.19.2",
+    "jquery": "^3.7.0",
+    "npm-run-all": "^4.1.5",
+    "@popperjs/core": "^2.11.8",
+    "postcss": "^8.4.29",
+    "postcss-cli": "^10.1.0",
+    "sass": "^1.66.1"
+  }
+}

--- a/packages/templates/cwpt-bootstrap/scss/_bootstrap.scss
+++ b/packages/templates/cwpt-bootstrap/scss/_bootstrap.scss
@@ -1,0 +1,52 @@
+// 1. Include functions first (so you can manipulate colors, SVGs, calc, etc)
+@import "../node_modules/bootstrap/scss/functions";
+
+// 2. Include any default variable overrides here
+@import "./overrides";
+
+// 3. Include remainder of required Bootstrap stylesheets (including any separate color mode stylesheets)
+@import "../node_modules/bootstrap/scss/variables";
+@import "../node_modules/bootstrap/scss/variables-dark";
+
+// 4. Include any default map overrides here
+
+// 5. Include remainder of required parts
+@import "../node_modules/bootstrap/scss/maps";
+@import "../node_modules/bootstrap/scss/mixins";
+@import "../node_modules/bootstrap/scss/root";
+
+// 6. Optionally include any other parts as needed
+@import "../node_modules/bootstrap/scss/utilities";
+@import "../node_modules/bootstrap/scss/reboot";
+@import "../node_modules/bootstrap/scss/type";
+@import "../node_modules/bootstrap/scss/images";
+@import "../node_modules/bootstrap/scss/containers";
+@import "../node_modules/bootstrap/scss/grid";
+@import "../node_modules/bootstrap/scss/tables";
+@import "../node_modules/bootstrap/scss/forms";
+@import "../node_modules/bootstrap/scss/buttons";
+@import "../node_modules/bootstrap/scss/transitions";
+@import "../node_modules/bootstrap/scss/dropdown";
+@import "../node_modules/bootstrap/scss/button-group";
+@import "../node_modules/bootstrap/scss/nav";
+@import "../node_modules/bootstrap/scss/navbar";
+@import "../node_modules/bootstrap/scss/card";
+@import "../node_modules/bootstrap/scss/accordion";
+@import "../node_modules/bootstrap/scss/breadcrumb";
+@import "../node_modules/bootstrap/scss/pagination";
+@import "../node_modules/bootstrap/scss/badge";
+@import "../node_modules/bootstrap/scss/alert";
+@import "../node_modules/bootstrap/scss/progress";
+@import "../node_modules/bootstrap/scss/list-group";
+@import "../node_modules/bootstrap/scss/close";
+@import "../node_modules/bootstrap/scss/toasts";
+@import "../node_modules/bootstrap/scss/modal";
+@import "../node_modules/bootstrap/scss/tooltip";
+@import "../node_modules/bootstrap/scss/popover";
+@import "../node_modules/bootstrap/scss/carousel";
+@import "../node_modules/bootstrap/scss/spinners";
+@import "../node_modules/bootstrap/scss/offcanvas";
+@import "../node_modules/bootstrap/scss/helpers";
+
+// 7. Optionally include utilities API last to generate classes based on the Sass map in `_utilities.scss`
+@import "../node_modules/bootstrap/scss/utilities/api";

--- a/packages/templates/cwpt-bootstrap/scss/_custom.scss
+++ b/packages/templates/cwpt-bootstrap/scss/_custom.scss
@@ -1,0 +1,1 @@
+// Write your custom styles here

--- a/packages/templates/cwpt-bootstrap/scss/_overrides.scss
+++ b/packages/templates/cwpt-bootstrap/scss/_overrides.scss
@@ -1,0 +1,1 @@
+// Write any default map overrides here

--- a/packages/templates/cwpt-bootstrap/scss/main.scss
+++ b/packages/templates/cwpt-bootstrap/scss/main.scss
@@ -1,0 +1,5 @@
+// Include selected Bootstrap parts
+@import "./bootstrap";
+
+// Include custom styles
+@import "./custom";


### PR DESCRIPTION
Resolves #2

This PR adds `Bootstrap` CSS template into the `create-wp-theme` toolkit to provide users with a starting point for WordPress theme development that includes Bootstrap-based styling. 