### PR TITLE
feat: add `cwpt-material` template

### DIFF
--- a/packages/templates/cwpt-material/.gitignore
+++ b/packages/templates/cwpt-material/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+.DS_Store
+/vscode
+**.zip

--- a/packages/templates/cwpt-material/js/main.js
+++ b/packages/templates/cwpt-material/js/main.js
@@ -1,0 +1,2 @@
+// Uncomment the line below for testing.
+// alert("Hello world from the theme's `main.js`");

--- a/packages/templates/cwpt-material/package.json
+++ b/packages/templates/cwpt-material/package.json
@@ -1,0 +1,33 @@
+{
+  "scripts": {
+    "build:scripts": "esbuild ./js/main.js --bundle --outfile=./theme/js/main.js",
+    "build:styles": "sass --load-path=node_modules ./scss/main.scss ./theme/css/main.css",
+    "build:prefix-styles:": "postcss --replace ./theme/css/main.css --use autoprefixer",
+    "development": "run-p build:**",
+    "dev": "npm run development",
+    "watch:scripts": "npm run build:scripts -- --watch",
+    "watch:styles": "npm run build:styles -- --watch",
+    "watch": "run-p watch:scripts watch:styles",
+    "watch:changes": "browser-sync start --proxy \"dev.local\" --files \"theme\" --no-inject-changes --no-notify",
+    "serve": "run-p watch watch:changes",
+    "serve:tunnel": "npm run serve -- --tunnel",
+    "production:scripts": "npm run build:scripts -- --minify",
+    "production:styles": "npm run build:styles -- --style compressed",
+    "production": "run-s production:** build:prefix-styles",
+    "prod": "npm run production",
+    "zip": "node node_scripts/zip.js _cwpt",
+    "bundle": "run-s production zip"
+  },
+  "devDependencies": {
+    "adm-zip": "^0.5.10",
+    "archiver": "^6.0.0",
+    "autoprefixer": "^10.4.15",
+    "browser-sync": "^2.29.3",
+    "esbuild": "0.19.2",
+    "material-components-web": "^14.0.0",
+    "npm-run-all": "^4.1.5",
+    "postcss": "^8.4.29",
+    "postcss-cli": "^10.1.0",
+    "sass": "^1.66.1"
+  }
+}

--- a/packages/templates/cwpt-material/scss/_custom.scss
+++ b/packages/templates/cwpt-material/scss/_custom.scss
@@ -1,0 +1,1 @@
+// Write your custom styles here

--- a/packages/templates/cwpt-material/scss/_material.scss
+++ b/packages/templates/cwpt-material/scss/_material.scss
@@ -1,0 +1,44 @@
+// Import Default variable overrides https://github.com/material-components/material-components-web/blob/master/packages/mdc-theme/README.md
+@use "./overrides";
+
+// Optional: Comment out all components that are not needed to reduce the filesize
+@use "@material/button/mdc-button";
+@use "@material/button";
+@use "@material/button/mixins";
+@use "@material/button/variables";
+@use "@material/card";
+@use "@material/checkbox/mdc-checkbox";
+@use "@material/form-field";
+@use "@material/chips/mdc-chips";
+@use "@material/data-table/mdc-data-table";
+@use "@material/data-table";
+@use "@material/data-table/mixins";
+@use "@material/data-table/variables";
+@use "@material/dialog/mdc-dialog";
+@use "@material/drawer/mdc-drawer";
+@use "@material/elevation/mdc-elevation";
+@use "@material/fab/mdc-fab";
+@use "@material/floating-label";
+@use "@material/icon-button/mdc-icon-button";
+@use "@material/image-list/mdc-image-list";
+@use "@material/layout-grid/mdc-layout-grid";
+@use "@material/line-ripple/mdc-line-ripple";
+@use "@material/linear-progress/mdc-linear-progress";
+@use "@material/list/mdc-list";
+@use "@material/menu/mdc-menu";
+@use "@material/menu-surface/mdc-menu-surface";
+@use "@material/notched-outline/mdc-notched-outline";
+@use "@material/radio/mdc-radio";
+@use "@material/ripple/mdc-ripple";
+@use "@material/select/mdc-select";
+@use "@material/slider/mdc-slider";
+@use "@material/snackbar/mdc-snackbar";
+@use "@material/switch";
+@use "@material/tab/mdc-tab";
+@use "@material/tab-bar/mdc-tab-bar";
+@use "@material/tab-indicator/mdc-tab-indicator";
+@use "@material/tab-scroller/mdc-tab-scroller";
+@use "@material/textfield/mdc-text-field";
+@use "@material/theme/mdc-theme";
+@use "@material/top-app-bar/mdc-top-app-bar";
+@use "@material/typography/mdc-typography";

--- a/packages/templates/cwpt-material/scss/_overrides.scss
+++ b/packages/templates/cwpt-material/scss/_overrides.scss
@@ -1,0 +1,13 @@
+// Write any default map overrides here
+$primary: #6200ee;
+$secondary: #03dac6;
+$background: #fff;
+
+@use "@material/theme" with (
+	$primary: $primary,
+	$secondary: $secondary,
+	$background: $background
+);
+
+$on-primary: if(contrast-tone($primary) == 'dark', #000, #fff);
+$on-secondary: if(contrast-tone($secondary) == 'dark', #000, #fff);

--- a/packages/templates/cwpt-material/scss/main.scss
+++ b/packages/templates/cwpt-material/scss/main.scss
@@ -1,0 +1,5 @@
+// Include selected Bootstrap parts
+@use "./material";
+
+// Include custom styles
+@import "./custom";


### PR DESCRIPTION
Resolves #3 

This PR adds `Material` CSS template into the `create-wp-theme` toolkit to provide users with a starting point for WordPress theme development that includes Material Design-based styling.