### PR TITLE
refactor: re-model project; implement `new` command in cli app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Create WordPress Theme
+# WP Theme
 
 A one-stop solution for crafting WordPress themes with finesse. Seamlessly bundled with a powerful tools that simplifies your development workflow.
 
@@ -6,7 +6,7 @@ A one-stop solution for crafting WordPress themes with finesse. Seamlessly bundl
 
 ### Online Generator
 
-Get Started by generating your theme with your favorite CSS framework with our [online generator](#)
+Get Started by generating your theme with your favorite CSS framework with our [online generator](#) (wip***)
 
 or
 
@@ -14,16 +14,16 @@ or
 
 You can use our cli tool by running the command below with your favorite CSS framework:
 
-### Bootstrap
+#### Bootstrap
 
 ```shell
-npx create-wp-theme <theme-name> --bootstrap
+npx wp-theme new <theme-name> --bootstrap
 ```
 
-### Material Design
+#### Material Design 
 
 ```shell
-npx create-wp-theme <theme-name> --material
+npx wp-theme new <theme-name> --material
 ```
 
 ### Installation

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,9 +1,9 @@
-# Create WordPress Theme CLI
+# WP Theme
 
-Create WP Theme CLI is a command-line tool designed to streamline WordPress theme development. With an intuitive interface, it empowers you to create, manage, and customize WordPress themes effortlessly.
+wp-theme is a command-line tool designed to streamline WordPress theme development. With an intuitive interface, it empowers you to create, manage, and customize WordPress themes effortlessly.
 
 ```shell
-npx create-wp-theme <theme-name>
+npm install wp-theme -g
 ```
 
 ## Quick start
@@ -13,13 +13,13 @@ Generate your starter theme/boilerplate with your favorite CSS framework by runn
 ### Bootstrap
 
 ```shell
-npx create-wp-theme <theme-name> --bootstrap
+npx wp-theme new <theme-name> --bootstrap
 ```
 
 ### Material Design
 
 ```shell
-npx create-wp-theme <theme-name> --material
+npx wp-theme new <theme-name> --material
 ```
 
 ### Installation

--- a/cli/index.js
+++ b/cli/index.js
@@ -6,6 +6,7 @@ import color from "picocolors";
 import minimist from "minimist";
 import { intro, cancel, spinner, note } from "@clack/prompts";
 import { fileExists } from "./utils/file-exist.js";
+import resolveCommand from "./lib/resolve-command.js";
 import resolveThemeName from "./lib/resolve-theme-name.js";
 import resolveCSSFramework from "./lib/resolve-css-framework.js";
 import injectThemeName from "./lib/inject-theme-name.js";
@@ -17,71 +18,76 @@ async function run() {
   const cwd = process.cwd();
   
   // start
-  intro(color.inverse("create-wp-theme"));
+  intro(color.inverse("wp-theme"));
 
   // get arguments
   const argv = minimist(process.argv.slice(2));
 
-  // get theme name from argv
-  // const themeNameFromArgv = argv._[0];
-  const themeName = await resolveThemeName(argv._[0]);
+  // get command and theme name from argv
+  const commandFromArgv = argv._[0];
+  const themeNameFromArgv = argv._[1];
 
-  // instantiate spinner
-  const s = spinner();
+  const command = await resolveCommand(commandFromArgv);
+  const themeName = await resolveThemeName(themeNameFromArgv);
 
-  // compute location to save file to
-  const filePath = path.join(cwd, themeName);
-
-  // check if location already exist
-  if (fileExists(filePath)) {
-    console.log();
-    cancel(color.red(`${filePath} already exists.`));
-    process.exit(1);
+  if (command === "new") {
+    // instantiate spinner
+    const s = spinner();
+  
+    // compute location to save file to
+    const filePath = path.join(cwd, themeName);
+  
+    // check if location already exist
+    if (fileExists(filePath)) {
+      console.log();
+      cancel(color.red(`${filePath} already exists.`));
+      process.exit(1);
+    }
+  
+    // get specified css framework - only if supported
+    const cssFramework = await resolveCSSFramework(argv);
+  
+    s.start("Copying theme files");
+  
+    // download cssFramework related package
+    const templateToCopy = `templates/cwpt-${cssFramework}`;
+    await downloadCWPTPackage(templateToCopy, themeName);
+  
+    // download node_script package
+    await downloadCWPTPackage("node_scripts", `${themeName}/node_scripts`);
+  
+    // download base `theme` package
+    await downloadCWPTPackage("theme", `${themeName}/theme`);
+  
+    s.stop("Files copied");
+  
+    s.start("Setting things up");
+  
+    // modify placeholders in package.json `bundle` script
+    const packageJsonFile = path.resolve(filePath, "package.json");
+    const packageJsonContent = fs.readFileSync(packageJsonFile, "utf-8");
+    injectThemeName(packageJsonFile, packageJsonContent, themeName);
+  
+    // modify placeholders in `theme/style.css`
+    const styleCssFile = path.resolve(filePath, "theme/style.css");
+    const styleCssContent = fs.readFileSync(styleCssFile, "utf-8");
+    injectThemeName(styleCssFile, styleCssContent, themeName);
+    injectCSSFramework(styleCssFile, styleCssContent, cssFramework);
+  
+    /**
+     * @todo consider modifying namespaces `cwpt` in `function.php` to theme name
+     */
+  
+    s.stop("You're all set!");
+  
+    // detect package manager and its command prefix
+    const { packageManager, commandPrefix } = resolvePackageManager();
+  
+    note(
+      `${color.cyan(`cd ${path.relative(cwd, filePath)}`)}\n${color.cyan(`${packageManager} install`)}\n${color.cyan(`${commandPrefix} watch`)}`, 
+      "Now run"
+    );
   }
-
-  // get specified css framework - only if supported
-  const cssFramework = await resolveCSSFramework(argv);
-
-  s.start("Copying theme files");
-
-  // download cssFramework related package
-  const templateToCopy = `templates/cwpt-${cssFramework}`;
-  await downloadCWPTPackage(templateToCopy, themeName);
-
-  // download node_script package
-  await downloadCWPTPackage("node_scripts", `${themeName}/node_scripts`);
-
-  // download base `theme` package
-  await downloadCWPTPackage("theme", `${themeName}/theme`);
-
-  s.stop("Files copied");
-
-  s.start("Setting things up");
-
-  // modify placeholders in package.json `bundle` script
-  const packageJsonFile = path.resolve(filePath, "package.json");
-  const packageJsonContent = fs.readFileSync(packageJsonFile, "utf-8");
-  injectThemeName(packageJsonFile, packageJsonContent, themeName);
-
-  // modify placeholders in `theme/style.css`
-  const styleCssFile = path.resolve(filePath, "theme/style.css");
-  const styleCssContent = fs.readFileSync(styleCssFile, "utf-8");
-  injectThemeName(styleCssFile, styleCssContent, themeName);
-  injectCSSFramework(styleCssFile, styleCssContent, cssFramework);
-
-  /**
-   * @todo consider modifying namespaces `cwpt` in `function.php` to theme name
-   */
-
-  s.stop("You're all set!");
-
-  // detect package manager and its command prefix
-  const { packageManager, commandPrefix } = resolvePackageManager();
-
-  note(
-    `${color.cyan(`cd ${path.relative(cwd, filePath)}`)}\n${color.cyan(`${packageManager} install`)}\n${color.cyan(`${commandPrefix} watch`)}`, 
-    "Now run"
-  );
 }
 
 run().catch(console.error);

--- a/cli/lib/resolve-command.js
+++ b/cli/lib/resolve-command.js
@@ -1,0 +1,36 @@
+import { select, cancel, isCancel } from "@clack/prompts";
+import { SUPPORTED_COMMANDS } from "../../packages/constants.js";
+
+/**
+ * Resolve a wp-theme `command` for process from arguments
+ * @param {string} commandFromArgv 
+ * @returns {Promise<string>}
+ */
+export default async function resolveCommand(commandFromArgv) {
+  const normalisedCommandFromArgv = commandFromArgv?.toLowerCase() ?? "";
+  
+  let command;
+  const supportedCommand = SUPPORTED_COMMANDS.find(S_C => S_C.command === normalisedCommandFromArgv);
+
+  if (!supportedCommand) {
+    command = await select({
+      message: "What'd you want to do?",
+      options: SUPPORTED_COMMANDS.map(({action, command, description}) => {
+        return {
+          label: action,
+          value: command,
+          hint: description
+        }
+      })
+    });
+
+    if (isCancel(command)) {
+      cancel("Operation cancelled.");
+      process.exit(0);
+    }
+  } else {
+    command = supportedCommand.command;
+  }
+
+  return command;
+}

--- a/cli/lib/resolve-theme-name.js
+++ b/cli/lib/resolve-theme-name.js
@@ -19,7 +19,7 @@ export default async function resolveThemeName(nameFromArgv) {
 
     if (isCancel(themeName)) {
       cancel(color.red("Operation cancelled."));
-      process.exit(1);
+      process.exit(0);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "wp-theme",
-  "version": "0.0.0",
+  "name": "wp-theme-project",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "description": "An all-in-one WordPress theme development toolkit with JavaScript bundler, sass/css compiler, and live-reloading server.",

--- a/packages/constants.js
+++ b/packages/constants.js
@@ -5,3 +5,11 @@ export const SUPPORTED_CSS_FRAMEWORK = [
     website: "https://getbootstrap.com/"
   }
 ];
+
+export const SUPPORTED_COMMANDS = [
+  {
+    action: "New WP Theme",
+    command: "new",
+    description: "Create a new WordPress boilerplate theme",
+  }
+];


### PR DESCRIPTION
This pull request renames the project in its entirety from `create-wp-theme` to `wp-theme`. It renames every instance of the name in the project and most important refactors the `cli` app implementing a more robust system of `command`. The PR implements functionality that allows support for the below command.

### the `new` command

The new command is a command used alongside the package name to create a new wordpress boilerplate theme, it can be ran in the various method below.

```shell
# Create new wordpress theme
npx wp-theme new
```

```shell
# Create new wordpress theme, with theme name and preferred css framework in a single prompt
npx wp-theme new my-theme-name --bootstrap
```

The new command can also be execute directly without `npx` if the `wp-theme` binary has been initially install globally, like so

```shell
# Install wp-theme globally
npm install wp-theme -g
```

then run...

```shell
# Create new wordpress theme
wp-theme new
```

```shell
# Create new wordpress theme, with theme name and preferred css framework in a single prompt
wp-theme new my-theme-name --bootstrap
```

### Changes Made

- Renamed all occurrences of `create-wp-theme` to `wp-theme`
- Implemented the `resolveCommand` function; this function takes the first process `argv` check whether its a supported command, returns a normalised command if it is a supported command and prompts for a valid command if command is not supported 

  ```js
  /**
   * Resolve a wp-theme `command` for process from arguments
   * @param {string} commandFromArgv 
   * @returns {Promise<string>}
   */
  export default async function resolveCommand(commandFromArgv) {
    const normalisedCommandFromArgv = commandFromArgv?.toLowerCase() ?? "";
    
    let command;
    const supportedCommand = SUPPORTED_COMMANDS.find(S_C => S_C.command === normalisedCommandFromArgv);
  
    if (!supportedCommand) {
      command = await select({
        message: "What'd you want to do?",
        options: SUPPORTED_COMMANDS.map(({action, command, description}) => {
          return {
            label: action,
            value: command,
            hint: description
          }
        })
      });
  
      if (isCancel(command)) {
        cancel("Operation cancelled.");
        process.exit(0);
      }
    } else {
      command = supportedCommand.command;
    }
  
    return command;
  }
  ```
- Added a new `SUPPORTED_COMMANDS` constant to track command that have been implemented in the project for support
- Integrate `resolveCommand` into the main `run` script, moving all current new theme creation logic under cases where resolved command equates to `new`.
- Updated the documentations
- Initialized the `wp-theme-project` version to `v0.1.0`

## Related Issue

Towards #14 

## Demo (Screencast/Screenshot)

[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2024.03.15-12_50_11.webm](https://github.com/babblebey/wp-theme/assets/25631971/77e48389-cdd4-4725-a91e-e72d63add3f5)
